### PR TITLE
Support aws glue catalog

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,3 +16,5 @@ jobs:
         run: ./gradlew build -x test -x ktlintCheck
       - name: Run tests
         run: ./gradlew test
+        env:
+          AWS_REGION: eu-west-1

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     assertk_jvm = '0.25'
     junit_jupiter_api = '5.8.1'
     junit_jupiter_engine = '5.8.1'
-    aws_sqs = '2.15.7'
+    aws = '2.15.40'
     iceberg_hive_metastore = '0.12.0'
     hadoop_aws = '3.2.0'
     hadoop_client = '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 ext {
-    iceberg_core = '0.12.1'
+    iceberg_core = '0.13.1'
     kotlin_stdlib = '1.6.0'
     mockk = '1.12.1'
     assertk_jvm = '0.25'

--- a/charts/narwhal/Chart.yaml
+++ b/charts/narwhal/Chart.yaml
@@ -3,5 +3,5 @@ name: narwhal
 description: Narwhal Helm chart for Kubernetes
 
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "0.0.1"

--- a/charts/narwhal/values.yaml
+++ b/charts/narwhal/values.yaml
@@ -15,11 +15,13 @@ fullnameOverride: ""
 
 configuration:
   catalog:
+    type: hive # hive | glue
     name: hive_prod
-    uris: thrift://<hive-metastore-uri>:9083
-    warehouse: /tmp
-    access_key: <aws access key>
-    secret_key: <aws secret key>
+    config:
+      fs.s3a.access.key: ""
+      fs.s3a.secret.key: ""
+      hive.metastore.uris: thrift://<hive-metastore-uri>:9083
+      hive.metastore.warehouse.dir: "file:///tmp"
 
   tables:
     - name: test_table_00

--- a/core/src/main/kotlin/io/datappeal/core/Analyzer.kt
+++ b/core/src/main/kotlin/io/datappeal/core/Analyzer.kt
@@ -27,7 +27,7 @@ class Analyzer(private val rewritePartitionPolicy: RewritePartitionPolicy) {
     }
 
     private fun tablePropertiesFilter(partition: AnalyzedTablePartition, params: Map<String, Any>): Boolean {
-        if (params.isNullOrEmpty()){
+        if (params.isEmpty()){
             return true
         }
 

--- a/core/src/main/kotlin/io/datappeal/core/Analyzer.kt
+++ b/core/src/main/kotlin/io/datappeal/core/Analyzer.kt
@@ -27,7 +27,7 @@ class Analyzer(private val rewritePartitionPolicy: RewritePartitionPolicy) {
     }
 
     private fun tablePropertiesFilter(partition: AnalyzedTablePartition, params: Map<String, Any>): Boolean {
-        if (params.isEmpty()){
+        if (params.isEmpty()) {
             return true
         }
 
@@ -38,7 +38,6 @@ class Analyzer(private val rewritePartitionPolicy: RewritePartitionPolicy) {
 
         return true
     }
-
 
     private fun listPartitions(table: Table): Map<List<Pair<String, Any?>>, List<DataFile>> {
         val planFiles = table.newScan()

--- a/core/src/main/kotlin/io/datappeal/core/analysis/rewritefiles/FileSkewPolicy.kt
+++ b/core/src/main/kotlin/io/datappeal/core/analysis/rewritefiles/FileSkewPolicy.kt
@@ -6,12 +6,10 @@ import kotlin.math.ceil
 class FileSkewPolicy : RewritePartitionPolicy {
 
     override fun rewrite(partition: AnalyzedTablePartition, params: Map<String, Any>): Boolean {
-        val fileSizeSkewThreshold : Double = params.getOrDefault("file_size_skew_threshold", 0.2) as Double
-
+        val fileSizeSkewThreshold: Double = params.getOrDefault("file_size_skew_threshold", 0.2) as Double
 
         val table = partition.table.properties().getOrDefault("write.target-file-size-bytes", "536870912").toLong()
-        val tableTargetFileSizeBytes : Long = (params.getOrDefault("target_file_size_bytes", table) as Number).toLong()
-
+        val tableTargetFileSizeBytes: Long = (params.getOrDefault("target_file_size_bytes", table) as Number).toLong()
 
         val partitionSizeBytes = partition.files.sumOf { it.fileSizeInBytes() }
 
@@ -24,6 +22,4 @@ class FileSkewPolicy : RewritePartitionPolicy {
         val maxFiles = targetFileCount + tolerance
         return currentFilesCount < minFiles || currentFilesCount > maxFiles
     }
-
-
 }

--- a/core/src/test/kotlin/io/datappeal/core/analysis/rewritefiles/FileSkewPolicyTest.kt
+++ b/core/src/test/kotlin/io/datappeal/core/analysis/rewritefiles/FileSkewPolicyTest.kt
@@ -24,13 +24,11 @@ class FileSkewPolicyTest {
         )
 
         val partitionKey = listOf(
-            Pair("pkey_0", "test"),
-            Pair("pkey_1", 1)
+            Pair("pkey_0", "test"), Pair("pkey_1", 1)
         )
 
         val partition = AnalyzedTablePartition(table, partitionKey, partitionFiles)
-        assertThat(policy.rewrite(partition, emptyMap()))
-            .isFalse()
+        assertThat(policy.rewrite(partition, emptyMap())).isFalse()
     }
 
     @Test
@@ -45,15 +43,18 @@ class FileSkewPolicyTest {
         )
 
         val partitionKey = listOf(
-            Pair("pkey_0", "test"),
-            Pair("pkey_1", 1)
+            Pair("pkey_0", "test"), Pair("pkey_1", 1)
         )
 
         val partition = AnalyzedTablePartition(table, partitionKey, partitionFiles)
-        assertThat(policy.rewrite(partition, mapOf(
-            "target_file_size_bytes" to 100
-        )))
-            .isTrue()
+        assertThat(
+            policy.rewrite(
+                partition,
+                mapOf(
+                    "target_file_size_bytes" to 100
+                )
+            )
+        ).isTrue()
     }
 
     private fun icebergFile(sizeBytes: Long = 1024 * 1024L): DataFile {

--- a/integration-aws/build.gradle
+++ b/integration-aws/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${rootProject.ext.kotlin_stdlib}"
 
-    implementation group: 'software.amazon.awssdk', name: 'bundle', version: '2.15.40'
+    implementation group: 'software.amazon.awssdk', name: 'bundle', version: "${rootProject.ext.aws}"
 
     implementation group: 'com.google.code.gson', name: 'gson', version: "${rootProject.ext.google_gson}"
 

--- a/integration-aws/build.gradle
+++ b/integration-aws/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${rootProject.ext.kotlin_stdlib}"
 
-    implementation group: 'software.amazon.awssdk', name: 'sqs', version: "${rootProject.ext.aws_sqs}"
+    implementation group: 'software.amazon.awssdk', name: 'bundle', version: '2.15.40'
 
     implementation group: 'com.google.code.gson', name: 'gson', version: "${rootProject.ext.google_gson}"
 

--- a/job/build.gradle
+++ b/job/build.gradle
@@ -4,8 +4,6 @@ dependencies {
 
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${rootProject.ext.kotlin_stdlib}"
 
-   // implementation group: 'software.amazon.awssdk', name: 'sqs', version: "${rootProject.ext.aws_sqs}"
-
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
     implementation group: 'org.apache.iceberg', name: 'iceberg-core', version: "${rootProject.ext.iceberg_core}"

--- a/job/build.gradle
+++ b/job/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: "${rootProject.ext.jackson_module_kotlin}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: "${rootProject.ext.jackson_dataformat_yaml}"
 
-    implementation group: 'software.amazon.awssdk', name: 'bundle', version: '2.15.40'
-    implementation group: 'software.amazon.awssdk', name: 'url-connection-client', version: '2.15.40'
+    implementation group: 'software.amazon.awssdk', name: 'bundle', version: "${rootProject.ext.aws}"
+    implementation group: 'software.amazon.awssdk', name: 'url-connection-client', version: "${rootProject.ext.aws}"
 
     testImplementation group: 'io.mockk', name: 'mockk', version: "${rootProject.ext.mockk}"
     testImplementation group: 'com.willowtreeapps.assertk', name: 'assertk-jvm', version: "${rootProject.ext.assertk_jvm}"

--- a/job/build.gradle
+++ b/job/build.gradle
@@ -4,10 +4,13 @@ dependencies {
 
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${rootProject.ext.kotlin_stdlib}"
 
-    implementation group: 'software.amazon.awssdk', name: 'sqs', version: "${rootProject.ext.aws_sqs}"
+   // implementation group: 'software.amazon.awssdk', name: 'sqs', version: "${rootProject.ext.aws_sqs}"
+
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
     implementation group: 'org.apache.iceberg', name: 'iceberg-core', version: "${rootProject.ext.iceberg_core}"
     implementation group: 'org.apache.iceberg', name: 'iceberg-hive-metastore', version: "${rootProject.ext.iceberg_hive_metastore}"
+    implementation group: 'org.apache.iceberg', name: 'iceberg-aws', version: "${rootProject.ext.iceberg_core}"
 
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: "${rootProject.ext.hadoop_aws}"
     implementation group: 'org.apache.hadoop', name: 'hadoop-client', version: "${rootProject.ext.hadoop_client}"
@@ -26,6 +29,8 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: "${rootProject.ext.jackson_module_kotlin}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: "${rootProject.ext.jackson_dataformat_yaml}"
 
+    implementation group: 'software.amazon.awssdk', name: 'bundle', version: '2.15.40'
+    implementation group: 'software.amazon.awssdk', name: 'url-connection-client', version: '2.15.40'
 
     testImplementation group: 'io.mockk', name: 'mockk', version: "${rootProject.ext.mockk}"
     testImplementation group: 'com.willowtreeapps.assertk', name: 'assertk-jvm', version: "${rootProject.ext.assertk_jvm}"

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/factory/CatalogFactory.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/factory/CatalogFactory.kt
@@ -1,25 +1,38 @@
 package io.datappeal.narwhal.job.factory
 
-import io.datappeal.narwhal.job.models.hive.CatalogConfig
+import io.datappeal.narwhal.job.models.catalog.CatalogConfig
 import org.apache.hadoop.conf.Configuration
+import org.apache.iceberg.aws.glue.GlueCatalog
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.hive.HiveCatalog
 
 class CatalogFactory {
     companion object {
-        // todo create implementation agnostic configuration
-        // at the moment only the hive catalog is supported
         fun createCatalog(catalogConf: CatalogConfig): Catalog {
-            val catalog = HiveCatalog()
-            val conf = Configuration()
-            conf.set("fs.s3a.access.key", catalogConf.access_key)
-            conf.set("fs.s3a.secret.key", catalogConf.secret_key)
-            conf.set("hive.metastore.uris", catalogConf.uris)
-            conf.set("hive.metastore.warehouse.dir", catalogConf.warehouse)
+            when (catalogConf.type) {
+                "hive" -> {
+                    val catalog = HiveCatalog()
+                    val conf = Configuration()
 
-            catalog.conf = conf
-            catalog.initialize(catalogConf.name, emptyMap())
-            return catalog
+                    for (entry in catalogConf.config) {
+                        conf.set(entry.key, entry.value)
+                    }
+
+                    catalog.conf = conf
+                    catalog.initialize(catalogConf.name, emptyMap())
+                    return catalog
+                }
+                "glue" -> {
+                    val catalog = GlueCatalog()
+                    catalog.initialize(catalogConf.name, catalogConf.config)
+                    return catalog
+                }
+                else -> {
+                    throw IllegalArgumentException("invalid catalog type: " + catalogConf.type)
+                }
+            }
         }
     }
+
+
 }

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/factory/CatalogFactory.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/factory/CatalogFactory.kt
@@ -33,6 +33,4 @@ class CatalogFactory {
             }
         }
     }
-
-
 }

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/factory/IntegrationFactory.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/factory/IntegrationFactory.kt
@@ -5,7 +5,6 @@ import io.datappeal.narwhal.integration.aws.SQSNotifier
 import io.datappeal.narwhal.job.models.enumerations.IntegrationEnum
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsClient

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/factory/IntegrationFactory.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/factory/IntegrationFactory.kt
@@ -5,6 +5,8 @@ import io.datappeal.narwhal.integration.aws.SQSNotifier
 import io.datappeal.narwhal.job.models.enumerations.IntegrationEnum
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder
+import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsClient
 
@@ -25,6 +27,7 @@ class IntegrationFactory {
                         integrationParams["queue"] as String,
                         batchSize,
                         SqsClient.builder()
+                            .httpClient(ApacheHttpClient.builder().build())
                             .credentialsProvider(
                                 StaticCredentialsProvider.create(
                                     AwsBasicCredentials.create(

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
@@ -19,7 +19,7 @@ class Launcher(
                 params = table.params.orEmpty()
             )
 
-            if (analyzeRewriteFiles.isEmpty()){
+            if (analyzeRewriteFiles.isEmpty()) {
                 continue
             }
 

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
@@ -23,7 +23,6 @@ class Launcher(
                 continue
             }
 
-            println("${table.schema}.${table.name}: ${analyzeRewriteFiles.size} partitions")
             this.integration.accept(
                 analyzeRewriteFiles
                     .map {

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/launcher/Launcher.kt
@@ -23,6 +23,7 @@ class Launcher(
                 continue
             }
 
+            println("${table.schema}.${table.name}: ${analyzeRewriteFiles.size} partitions")
             this.integration.accept(
                 analyzeRewriteFiles
                     .map {

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/main/JobCmd.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/main/JobCmd.kt
@@ -32,11 +32,9 @@ class JobCmd : CliktCommand() {
             TargetTable(it.name, it.schema, jobConfig.rewrite_files.policy.params + it.params.orEmpty())
         }
 
-    val analyzer = Analyzer(rewritePartitionPolicy)
+        val analyzer = Analyzer(rewritePartitionPolicy)
         Launcher(
-            catalog = catalog,
-            analyzer = analyzer,
-            integration = integration
+            catalog = catalog, analyzer = analyzer, integration = integration
         ).launch(tablesWithConfig)
     }
 }

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/models/JobConfig.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/models/JobConfig.kt
@@ -1,6 +1,6 @@
 package io.datappeal.narwhal.job.models
 
-import io.datappeal.narwhal.job.models.hive.CatalogConfig
+import io.datappeal.narwhal.job.models.catalog.CatalogConfig
 import io.datappeal.narwhal.job.models.rewrite_file.RewriteFilesConfig
 
 data class TargetTable(

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/models/catalog/CatalogConfig.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/models/catalog/CatalogConfig.kt
@@ -1,0 +1,7 @@
+package io.datappeal.narwhal.job.models.catalog
+
+data class CatalogConfig(
+    val type: String,
+    val name: String,
+    val config: Map<String, String>,
+)

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/models/hive/CatalogConfig.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/models/hive/CatalogConfig.kt
@@ -1,9 +1,0 @@
-package io.datappeal.narwhal.job.models.hive
-
-data class CatalogConfig(
-    val name: String,
-    val uris: String,
-    val warehouse: String,
-    val access_key: String,
-    val secret_key: String
-)

--- a/job/src/main/kotlin/io/datappeal/narwhal/job/models/rewrite_file/RewriteFilesConfig.kt
+++ b/job/src/main/kotlin/io/datappeal/narwhal/job/models/rewrite_file/RewriteFilesConfig.kt
@@ -5,6 +5,5 @@ import io.datappeal.narwhal.job.models.integration.IntegrationConfig
 data class RewriteFilesConfig(
     val enabled: Boolean,
     val policy: RewriteFilePolicyConfig,
-    val integration: IntegrationConfig
+    val integration: IntegrationConfig,
 )
-

--- a/job/src/test/kotlin/io/datappeal/narwhal/job/config/ConfigReaderTest.kt
+++ b/job/src/test/kotlin/io/datappeal/narwhal/job/config/ConfigReaderTest.kt
@@ -61,7 +61,6 @@ class ConfigReaderTest {
             .isInstanceOf(HiveCatalog::class)
     }
 
-
     @Test
     fun `should create correct glue catalog`() {
         val glueCatalog = CatalogFactory.createCatalog(
@@ -76,5 +75,4 @@ class ConfigReaderTest {
         assertThat(glueCatalog)
             .isInstanceOf(GlueCatalog::class)
     }
-
 }

--- a/job/src/test/kotlin/io/datappeal/narwhal/job/config/ConfigReaderTest.kt
+++ b/job/src/test/kotlin/io/datappeal/narwhal/job/config/ConfigReaderTest.kt
@@ -5,7 +5,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import io.datappeal.narwhal.job.factory.CatalogFactory
 import io.datappeal.narwhal.job.models.TargetTable
-import io.datappeal.narwhal.job.models.hive.CatalogConfig
+import io.datappeal.narwhal.job.models.catalog.CatalogConfig
+import org.apache.iceberg.aws.glue.GlueCatalog
 import org.apache.iceberg.hive.HiveCatalog
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,10 +24,12 @@ class ConfigReaderTest {
         assertThat(jobConfig.catalog).isEqualTo(
             CatalogConfig(
                 name = "name",
-                uris = "uris",
-                warehouse = "warehouse",
-                access_key = "access_key",
-                secret_key = "secret_key"
+                type = "hive",
+                config = mapOf(
+                    "warehouse" to "warehouse",
+                    "access_key" to "access_key",
+                    "secret_key" to "secret_key",
+                ),
             )
         )
         assertThat(jobConfig.tables).isEqualTo(
@@ -34,24 +37,44 @@ class ConfigReaderTest {
                 TargetTable(
                     name = "test_table",
                     schema = "test_schema",
-                    params = emptyMap()
+                    params = mapOf(
+                        "target_file_size_bytes" to 2,
+                        "file_size_skew_threshold" to 1,
+                    )
                 )
             )
         )
     }
 
     @Test
-    fun `should create correct hiveConfig`() {
+    fun `should create correct hive catalog`() {
         val hiveCatalog = CatalogFactory.createCatalog(
             CatalogConfig(
                 name = "name",
-                uris = "uris",
-                warehouse = "warehouse",
-                access_key = "access_key",
-                secret_key = "secret_key"
+                type = "hive",
+                config = mapOf(
+                    "warehouse" to "file:///tmp",
+                ),
             )
         )
         assertThat(hiveCatalog)
             .isInstanceOf(HiveCatalog::class)
     }
+
+
+    @Test
+    fun `should create correct glue catalog`() {
+        val glueCatalog = CatalogFactory.createCatalog(
+            CatalogConfig(
+                name = "name",
+                type = "glue",
+                config = mapOf(
+                    "warehouse" to "file:///tmp",
+                ),
+            )
+        )
+        assertThat(glueCatalog)
+            .isInstanceOf(GlueCatalog::class)
+    }
+
 }

--- a/job/src/test/resources/config_test.yml
+++ b/job/src/test/resources/config_test.yml
@@ -1,25 +1,29 @@
 tables:
   - name: "test_table"
     schema: "test_schema"
-  
+    params: # Map<String, Any> ...
+      target_file_size_bytes: 2
+      file_size_skew_threshold: 1
+
 catalog:
+  type: hive
   name: name
-  uris: uris
-  warehouse: warehouse
-  access_key: access_key
-  secret_key: secret_key
+  config:
+    warehouse: warehouse
+    access_key: access_key
+    secret_key: secret_key
 
 rewrite_files:
   enabled: true
   policy:
     type: type
-    config: # Map<String, Any> ...
+    params: # Map<String, Any> ...
       target_file_size_bytes: 1
       file_size_skew_threshold: 0.2
 
   integration:
     type: type
-    config: # Map<String, Any>
+    params: # Map<String, Any>
       region: region
       queue: queue
       batch_size: 10


### PR DESCRIPTION
* Add support for multiple catalogs ( hive, glue ) 
* Add custom configuration for catalog ( instead of explicit parameters remapping )
* Bump `apache-icerberg` to `0.13.1` in order to fix Glue table name compatibility issue